### PR TITLE
organizaiton: update task issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/task-issue-template.md
@@ -26,26 +26,12 @@ _The issue is considered complete when all the following criteria are met:_
 - [ ] Code follows the project's style guidelines and best practices.  
 - [ ] Deployed and verified in the staging environment (if applicable).  
 
-### 📌 Out of Scope  
-_Clarify what is explicitly NOT included in this issue to avoid scope creep._  
-
 ### 🔗 Dependencies  
 - _List any dependencies that need to be resolved before this issue can be completed._  
 - _Include links to related issues or pull requests._  
 
 ### ⚙️ Technical Notes  
 _Any technical considerations, such as architectural decisions, third-party tools, or libraries to be used._  
-
-### 💡 Additional Context  
-_Include any additional information that could help in the implementation, such as:_  
-- _Links to designs, specifications, or relevant discussions._  
-- _Performance, security, or usability considerations._  
-
-### 👥 Assignees  
-- _Who is responsible for this issue?_  
-
-### 📅 Estimated Time  
-_Optional: Estimated time required to complete the task._  
 
 ### 📝 Comments  
 _Any other notes, questions, or comments related to the issue._


### PR DESCRIPTION
This pull request focuses on cleaning up and simplifying the issue template for task issues. The most significant changes include the removal of several sections that were deemed unnecessary.

Simplification of issue template:

* [`.github/ISSUE_TEMPLATE/task-issue-template.md`](diffhunk://#diff-742e792a22a88997d308c9249331c59b574e71e8af44f304c961c725febacd64L29-L49): Removed the "Out of Scope" section to avoid redundancy and potential scope creep.
* [`.github/ISSUE_TEMPLATE/task-issue-template.md`](diffhunk://#diff-742e792a22a88997d308c9249331c59b574e71e8af44f304c961c725febacd64L29-L49): Removed the "Additional Context" section to streamline the template and reduce clutter.
* [`.github/ISSUE_TEMPLATE/task-issue-template.md`](diffhunk://#diff-742e792a22a88997d308c9249331c59b574e71e8af44f304c961c725febacd64L29-L49): Removed the "Assignees" section to simplify the template and remove redundant information.
* [`.github/ISSUE_TEMPLATE/task-issue-template.md`](diffhunk://#diff-742e792a22a88997d308c9249331c59b574e71e8af44f304c961c725febacd64L29-L49): Removed the "Estimated Time" section as it was optional and often left blank.