### PR TITLE
fix: ensure wishlist exists

### DIFF
--- a/lib/wishlist/actions.ts
+++ b/lib/wishlist/actions.ts
@@ -18,7 +18,11 @@ async function getWishlistByUserId(userId: number): Promise<Wishlist | null> {
     .where(eq(wishlists.userId, userId))
     .limit(1);
 
-  return wishlist[0] as Wishlist || null;
+  if (wishlist.length === 0) {
+    return null;
+  } else {
+    return wishlist[0] as Wishlist;
+  }
 }
 
 async function getOrCreateWishlistByUserId(userId: number): Promise<Wishlist> {

--- a/lib/wishlist/actions.ts
+++ b/lib/wishlist/actions.ts
@@ -16,8 +16,19 @@ async function getWishlistByUserId(userId: number) {
   return wishlist[0];
 }
 
-export async function getWishlistListingsByUserId(userId: number) {
+async function getOrCreateWishlistByUserId(userId: number) {
   const wishlist = await getWishlistByUserId(userId);
+
+  if (!wishlist) {
+    await createWishlist(userId);
+    return getWishlistByUserId(userId);
+  }
+
+  return wishlist;
+}
+
+export async function getWishlistListingsByUserId(userId: number) {
+  const wishlist = await getOrCreateWishlistByUserId(userId);
 
   return db
     .select({ id: wishlistListings.listingId, title: listings.title })
@@ -27,7 +38,7 @@ export async function getWishlistListingsByUserId(userId: number) {
 }
 
 export async function addListingToWishlist(userId: number, listingId: number) {
-  const wishlist = await getWishlistByUserId(userId);
+  const wishlist = await getOrCreateWishlistByUserId(userId);
 
   return db.insert(wishlistListings).values({
     wishlistId: wishlist.id,
@@ -36,7 +47,7 @@ export async function addListingToWishlist(userId: number, listingId: number) {
 }
 
 export async function removeListingFromWishlist(userId: number, listingId: number) {
-  const wishlist = await getWishlistByUserId(userId);
+  const wishlist = await getOrCreateWishlistByUserId(userId);
 
   return db
     .delete(wishlistListings)
@@ -49,7 +60,7 @@ export async function removeListingFromWishlist(userId: number, listingId: numbe
 }
 
 export async function clearWishlist(userId: number) {
-  const wishlist = await getWishlistByUserId(userId);
+  const wishlist = await getOrCreateWishlistByUserId(userId);
 
   return db
     .delete(wishlistListings)

--- a/tests/wishlist/actions.test.ts
+++ b/tests/wishlist/actions.test.ts
@@ -106,7 +106,10 @@ describe('wishlist actions', () => {
   })
 
   it('createWishlist inserts a new wishlist', async () => {
-    const insertBuilder = { values: jest.fn().mockResolvedValue({ id: 11 }) }
+    const insertBuilder = { 
+      values: jest.fn().mockReturnThis(),
+      returning: jest.fn().mockResolvedValue([{ id: 11 }])
+    }
     insertMock.mockReturnValue(insertBuilder)
 
     const res = await actions.createWishlist(77)
@@ -125,5 +128,28 @@ describe('wishlist actions', () => {
     expect(deleteMock).toHaveBeenCalledWith(wishlists)
     expect(deleteBuilder.where).toHaveBeenCalledWith(expect.any(Object))
     expect(res).toEqual({ success: true })
+  })
+
+  it('creates a new wishlist if none is found', async () => {
+    const insertBuilder = { 
+      values: jest.fn().mockReturnThis(),
+      returning: jest.fn().mockResolvedValue([{ id: 15 }])
+    }
+    const selectBuilder = {
+      from: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue([]),
+      innerJoin: jest.fn().mockReturnThis(),
+    }
+
+    selectMock.mockImplementationOnce(() => selectBuilder)
+    insertMock.mockReturnValue(insertBuilder)
+
+    selectMock.mockImplementationOnce(() => selectBuilder)
+    await actions.getWishlistListingsByUserId(99)
+
+    expect(selectMock).toHaveBeenCalledWith()
+    expect(insertMock).toHaveBeenCalledWith(wishlists)
+    expect(insertBuilder.values).toHaveBeenCalledWith({ userId: 99 })
   })
 })


### PR DESCRIPTION
This pull request refactors and enhances wishlist-related functionality by introducing a new `getOrCreateWishlistByUserId` helper method, updating related functions to use it, and improving test coverage. The most important changes include ensuring a wishlist is automatically created if one does not exist, modifying the `createWishlist` function to return the created wishlist, and adding a new test case for the wishlist creation logic.

### Wishlist functionality improvements:
* Introduced a new `getOrCreateWishlistByUserId` function to ensure a wishlist is created if none exists, replacing calls to `getWishlistByUserId` in `addListingToWishlist`, `removeListingFromWishlist`, and `clearWishlist` functions. [[1]](diffhunk://#diff-77aada4e7a2c90b70217cb90cd544e79574032a2c45bacb8528f031de479fbb0L9-R37) [[2]](diffhunk://#diff-77aada4e7a2c90b70217cb90cd544e79574032a2c45bacb8528f031de479fbb0L30-R46) [[3]](diffhunk://#diff-77aada4e7a2c90b70217cb90cd544e79574032a2c45bacb8528f031de479fbb0L39-R55) [[4]](diffhunk://#diff-77aada4e7a2c90b70217cb90cd544e79574032a2c45bacb8528f031de479fbb0L52-R77)
* Updated `createWishlist` to return the newly created wishlist as a `Wishlist` object, using the `returning` method to retrieve inserted data.

### Test coverage enhancements:
* Updated the `createWishlist` test to mock the `returning` method and validate the returned data.
* Added a new test case to verify that a wishlist is automatically created when none exists, ensuring the `getOrCreateWishlistByUserId` function works as intended.