### PR TITLE
fix: oauth accounts

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -30,11 +30,6 @@ export async function fetchImageAsBase64(imageUrl: string): Promise<string | nul
   }
 }
 
-export function generateUiqueUsername(username: string): string {
-  const uniqueSuffix = `_${Math.random().toString(36).substring(2, 8)}`; // so that users with the same and last name can register
-  return `${username}${uniqueSuffix}`;
-}
-
 const providers: Array<ReturnType<typeof CredentialsProvider | typeof GoogleProvider>> = [
   CredentialsProvider({
     name: 'Credentials',

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,7 +1,7 @@
 import CredentialsProvider from "next-auth/providers/credentials";
 import GoogleProvider from "next-auth/providers/google";
 import { NextAuthOptions, Profile } from "next-auth";
-import { findUserByEmail, createUser } from "@/lib/users/actions";
+import { findUserByEmail, createUser, findUserByUsername } from "@/lib/users/actions";
 import bcrypt from "bcryptjs";
 import { db } from "./db";
 import { oauthAccounts } from "./db/schema/oauth_accounts";
@@ -28,6 +28,11 @@ export async function fetchImageAsBase64(imageUrl: string): Promise<string | nul
     console.error('Error fetching profile image:', error);
     return null;
   }
+}
+
+export function generateUiqueUsername(username: string): string {
+  const uniqueSuffix = `_${Math.random().toString(36).substring(2, 8)}`; // so that users with the same and last name can register
+  return `${username}${uniqueSuffix}`;
 }
 
 const providers: Array<ReturnType<typeof CredentialsProvider | typeof GoogleProvider>> = [
@@ -154,9 +159,16 @@ export const authOptions: NextAuthOptions = {
         }
 
         // Create new user and OAuth account
+        // Check if the username already exists
+        const existingUsername = await findUserByUsername(profile?.name?.replace(/\s+/g, '') as string);
+        let uniqueSuffix = '';
+        if (existingUsername) {
+          uniqueSuffix = `_${Math.random().toString(36).substring(2, 8)}`; // so that users with the same first and last name can register
+        }
+
         const newUser = await createUser({
           email: profile?.email as string,
-          username: profile?.name?.replace(/\s+/g, '') as string,
+          username: `${profile?.name?.replace(/\s+/g, '')}${uniqueSuffix}` as string,
           passwordHash: null,
           role: 'user',
           profileImageId: photoId,

--- a/tests/api/auth/google.test.ts
+++ b/tests/api/auth/google.test.ts
@@ -3,14 +3,18 @@
  */
 
 import { authOptions, GoogleProfile } from '@/lib/auth';
-import { findUserByEmail, createUser } from '@/lib/users/actions';
+import { findUserByEmail, createUser, findUserByUsername } from '@/lib/users/actions';
 import { db } from '@/lib/db';
 import { oauthAccounts } from '@/lib/db/schema/oauth_accounts';
 import type { User } from '@/lib/db/schema/users';
 import type { Account, Profile } from 'next-auth';
 
 // Mock the needed services and dependencies
-jest.mock('@/lib/users/actions');
+jest.mock('@/lib/users/actions', () => ({
+  findUserByEmail: jest.fn(),
+  createUser: jest.fn(),
+  findUserByUsername: jest.fn(),
+}));
 jest.mock('@/lib/db', () => ({
   db: {
     select: jest.fn(() => ({
@@ -229,11 +233,14 @@ describe('Google OAuth Authentication', () => {
     // Mock no existing user
     (findUserByEmail as jest.Mock).mockResolvedValueOnce(null);
 
+    // Mock no existing username
+    (findUserByUsername as jest.Mock).mockResolvedValueOnce(null);
+
     // Mock user creation
     (createUser as jest.Mock).mockResolvedValueOnce({
       id: 1,
       email: 'test@example.com',
-      username: 'testuser',
+      username: 'TestUser',
     } as User);
 
     // Mock fetch error
@@ -253,4 +260,4 @@ describe('Google OAuth Authentication', () => {
     }));
     expect(db.insert).toHaveBeenCalledWith(oauthAccounts);
   });
-}); 
+});


### PR DESCRIPTION
## Original Issue:
For OAuth-registered users, usernames were generated by concatenating their first and last names. This caused conflicts when multiple users had the same name and surname, preventing new accounts from being created.

## Fix:
To resolve this, a unique suffix is now added to the username if a conflict is detected, ensuring each username remains unique.